### PR TITLE
Add Inputs for Access Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ module "public_static_bucket" {
     error_document = "index.html"
   }]
 
+  logging = [
+    {
+      target_bucket = "loggingbucketname"
+      target_prefix = "log/"
+    }
+
   cors_allowed_origins = ["*"]
   cors_allowed_headers = ["*"]
   cors_allowed_methods = ["GET"]
@@ -91,6 +97,7 @@ These variables have default values and don't have to be set to use this module.
 - cors_expose_headers
 - cors_max_age_seconds
 - description
+- logging
 - name
 - read_permissions
 - read_roles

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "public_static_bucket" {
       target_bucket = "logging-bucket-name"
       target_prefix = "log/"
     }
+  ]
 
   cors_allowed_origins = ["*"]
   cors_allowed_headers = ["*"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "public_static_bucket" {
 
   logging = [
     {
-      target_bucket = "loggingbucketname"
+      target_bucket = "logging-bucket-name"
       target_prefix = "log/"
     }
 

--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,9 @@ locals {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket        = "${lower(local.id)}"
-  acl           = "${var.acl}"
-  tags          = "${var.tags}"
+  bucket = "${lower(local.id)}"
+  acl    = "${var.acl}"
+  tags   = "${var.tags}"
 
   cors_rule {
     allowed_headers = "${var.cors_allowed_headers}"
@@ -14,6 +14,8 @@ resource "aws_s3_bucket" "this" {
     expose_headers  = "${var.cors_expose_headers}"
     max_age_seconds = "${var.cors_max_age_seconds}"
   }
+
+  logging = "${var.logging}"
 
   versioning {
     enabled = "${var.versioning_enabled}"
@@ -25,39 +27,39 @@ resource "aws_s3_bucket" "this" {
 }
 
 resource "aws_s3_bucket_policy" "access_identity" {
-  count = "${var.access_identity ? 1 : 0}"
+  count  = "${var.access_identity ? 1 : 0}"
   bucket = "${aws_s3_bucket.this.id}"
   policy = "${data.template_file.access_identity.rendered}"
 }
 
 resource "aws_s3_bucket_policy" "public" {
-  count = "${var.acl == "public-read" ? 1 : 0}"
+  count  = "${var.acl == "public-read" ? 1 : 0}"
   bucket = "${aws_s3_bucket.this.id}"
   policy = "${data.template_file.public.rendered}"
 }
 
 resource "aws_iam_policy" "read" {
-  count = "${length(var.read_roles) > 0 ? 1 : 0}"
-  name   = "${local.id}-S3-Read"
+  count       = "${length(var.read_roles) > 0 ? 1 : 0}"
+  name        = "${local.id}-S3-Read"
   description = "${var.description} Read"
-  policy = "${data.aws_iam_policy_document.read.json}"
+  policy      = "${data.aws_iam_policy_document.read.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "read" {
-  count = "${length(var.read_roles)}"
-  role = "${element(var.read_roles, count.index)}"
+  count      = "${length(var.read_roles)}"
+  role       = "${element(var.read_roles, count.index)}"
   policy_arn = "${aws_iam_policy.read.arn}"
 }
 
 resource "aws_iam_policy" "write" {
-  count = "${length(var.write_roles) > 0 ? 1 : 0}"
-  name   = "${local.id}-S3-Write"
+  count       = "${length(var.write_roles) > 0 ? 1 : 0}"
+  name        = "${local.id}-S3-Write"
   description = "${var.description} Write"
-  policy = "${data.aws_iam_policy_document.write.json}"
+  policy      = "${data.aws_iam_policy_document.write.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "write" {
-  count = "${length(var.write_roles)}"
-  role = "${element(var.write_roles, count.index)}"
+  count      = "${length(var.write_roles)}"
+  role       = "${element(var.write_roles, count.index)}"
   policy_arn = "${aws_iam_policy.write.arn}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,11 @@ variable "cors_max_age_seconds" {
   default = "0"
 }
 
+variable "logging" {
+  type    = "list"
+  default = []
+}
+
 variable "access_identity_arn" {
   default = ""
 }
@@ -48,7 +53,7 @@ variable "access_identity" {
 variable "read_permissions" {
   default = [
     "s3:GetObject",
-    "s3:ListBucket"
+    "s3:ListBucket",
   ]
 
   type        = "list"
@@ -58,7 +63,7 @@ variable "read_permissions" {
 variable "write_permissions" {
   default = [
     "s3:PutObject",
-    "s3:DeleteObject"
+    "s3:DeleteObject",
   ]
 
   type        = "list"


### PR DESCRIPTION
This PR simply adds two new input variables to support access logging from the bucket.

logging_target_bucket to specify your target bucket arn

logging_target_prefix to specify your log object prefix.