### PR TITLE
replication_configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ module "nonpublic_files_bucket" {
 }
 ```
 
+## Add bucket replication
+
+
+``` yaml
+  replication_role = aws_iam_role.replication.arn
+  replication_rules = [
+    {
+      id = "${local.name}-qa-replication"
+      status = "Enabled"
+      #prefix = "foo"
+      destination-bucket = var.app["arn-bucket-rep-dest"]
+      destination-storage_class = "STANDARD"
+    }
+  ]      
+```
+
+
 ## How to reference the bucket
 >
 > Examples using the *nonpublic_files_bucket* sample:

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,25 @@ resource "aws_s3_bucket" "this" {
       }
     }
   }
+  
+  dynamic "replication_configuration" {
+    for_each = var.replication_role != "" ? [var.replication_role] : []
+    content {
+      role = var.replication_role
+      dynamic rules {
+        for_each = var.replication_rules
+        content {
+          id     = rules.value.id
+          prefix = lookup(rules.value, "rules-prefix", null)
+          status = rules.value.status
+          destination {
+            bucket        = rules.value.destination-bucket
+            storage_class = rules.value.destination-storage_class
+          }
+        }
+      }
+    }
+  
 }
 
 resource "aws_s3_bucket_policy" "access_identity" {

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,14 @@ variable "lifecycle_rule" {
   type        = list
   default     = []
 }
+
+ variable "replication_rules" {
+    description = "Replication rules"
+    type = list
+    default = []
+ }
+
+ variable "replication_role" {
+    description = "Replication role"
+    default = ""
+ }


### PR DESCRIPTION
Fue agregado el soporte para replication_configuration, se puede agrega u omitir las configuraciones. En el readme del repo agregué qué un ejemplo de cómo usarlo. 